### PR TITLE
fix list formatting

### DIFF
--- a/episodes/analyzing.md
+++ b/episodes/analyzing.md
@@ -41,13 +41,15 @@ In this example, the coding scheme includes: task, emotional state, and memory i
 
 ## Categorizing errors
 If you are interested in errors, you may use error categories as part of your coding scheme. Common error types include: 
-- Failed attempts: Entering invalid data, such as incorrect login credentials or formatting errors.
+
+- Failed attempts: Entering invalid data, such as incorrect login credentials or formatting errors. 
 - Misnavigation: Navigating to unintended pages or sections.
 - Repeated actions: Attempting the same action multiple times unsuccessfully.
 - Incomplete tasks: Abandoning a task or failing to achieve the intended goal.
 - System errors: Triggering error messages or encountering broken functionality.
 
 You could also assign a severity to errors. A severity scale you could use is: 
+
 - Critical: Prevents users from completing a task (e.g., broken functionality or unclear instructions).
 - Moderate: Slows users down or causes frustration but doesn't prevent task completion.
 - Minor: Small mistakes with minimal impact on task completion.


### PR DESCRIPTION
Markdown lists need a blank line before the initial bulleted item. (I *always* forget this!)

Here's what this looked like before: 

<img width="813" height="346" alt="Screenshot 2025-11-17 at 4 51 10 PM" src="https://github.com/user-attachments/assets/25c593ab-958c-4377-8069-41eda2ef24c6" />

And after introducing blank lines:

<img width="761" height="378" alt="Screenshot 2025-11-17 at 4 51 17 PM" src="https://github.com/user-attachments/assets/31aeb679-09eb-4a0c-aa39-0bf43e98ece0" />
